### PR TITLE
Remove browserstack access key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,5 @@ php:
   - '7.0'
 
 before_install:
-  - true && `base64 --decode <<< ZXhwb3J0IEJST1dTRVJTVEFDS19BQ0NFU1NfS0VZPUh5VmZydXJvb3dYb041eGhLZEs2Cg==`
   - true && composer install
 


### PR DESCRIPTION
It looks like someone's access key got committed here - should either be documented or removed?

    $ base64 --decode <<< ZXhwb3J0IEJST1dTRVJTVEFDS19BQ0NFU1NfS0VZPUh5VmZydXJvb3dYb041eGhLZEs2Cg==
    export BROWSERSTACK_ACCESS_KEY=HyVfruroowXoN5xhKdK6